### PR TITLE
Feat: add force arg to overwrite config

### DIFF
--- a/bin/moneyd.js
+++ b/bin/moneyd.js
@@ -54,6 +54,12 @@ Object.keys(Moneyd.uplinks).forEach((uplinkName) => {
     command: uplinkName + ':configure',
     describe: 'Generate a configuration file',
     builder: {
+      force: {
+        type: 'boolean',
+        alias: 'f',
+        default: false,
+        description: 'Set to overwrite existing configuration'
+      },
       advanced: {
         type: 'boolean',
         default: false,

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class Moneyd {
 
   static async buildConfig (uplinkName, argv) {
     const config = new Config(argv.config)
-    if (config.getUplinkData(uplinkName)) {
+    if (config.getUplinkData(uplinkName) && !argv.force) {
       throw new Error('config already exists for uplinkName=' + uplinkName + ' file=' + argv.config)
     }
 


### PR DESCRIPTION
Sometimes it can be annoying to delete your existing moneyd config for an uplink by hand. This allows you to pass `--force` into the configure command in order to overwrite existing data.