### PR TITLE
Print help message when put wrong command (#32)

### DIFF
--- a/bin/moneyd.js
+++ b/bin/moneyd.js
@@ -102,12 +102,9 @@ Object.keys(Moneyd.uplinks).forEach((uplinkName) => {
   })
 })
 
-// eslint-disable-next-line no-unused-expressions
 yargs
-  .command('*', '', {}, argv => {
-    console.error('unknown command.')
-    process.exit(1)
-  })
+  .demandCommand()
+  .strict()
   .argv
 
 function addUplinkCommand (uplinkName, cmd) {


### PR DESCRIPTION
# To improve the command line help message, whenever input wrong command or option, it will show help message. 
1. if the command is wrong, it will show help message,  exact the same as "moneyd --help"
2. if the command is correct, but option is wrong, it will show help message with corresponding options to that command.