### PR TITLE
Add IDE specific gitignores and set npm dev as default local moneyd execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\"",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "dev": "./bin/moneyd.js local"
   },
   "author": "Ben Sharafian",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Adds `npm dev` as an option to run a `moneyd local` with default settings for developers.
- Adds `.idea/` to the `.gitignore` for contributors using JetBrains IDEs.